### PR TITLE
Refactoring folder structure of execution-manger to template-manager

### DIFF
--- a/modules/distribution/src/assembly/bin.xml
+++ b/modules/distribution/src/assembly/bin.xml
@@ -188,7 +188,7 @@
         <fileSet>
             <directory>.</directory>
             <outputDirectory>
-                ${pom.artifactId}-${pom.version}/repository/conf/execution-manager/domain-template
+                ${pom.artifactId}-${pom.version}/repository/conf/template-manager/domain-template
             </outputDirectory>
             <excludes>
                 <exclude>**/*</exclude>
@@ -672,7 +672,7 @@
             <source>
                 repository/conf/domain-template/temperature-analysis.xml
             </source>
-            <outputDirectory>${pom.artifactId}-${pom.version}/repository/conf/execution-manager/domain-template</outputDirectory>
+            <outputDirectory>${pom.artifactId}-${pom.version}/repository/conf/template-manager/domain-template</outputDirectory>
             <filtered>true</filtered>
         </file>
 


### PR DESCRIPTION
This is due to renaming the folder structure of execution manger to template manager